### PR TITLE
Add chat widget hide control and font customization

### DIFF
--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -5,7 +5,8 @@
 :host {
   --chatbot-container-bg-image: none;
   --chatbot-container-bg-color: transparent;
-  --chatbot-container-font-family: 'Open Sans';
+  --chatbot-container-font-family: 'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 
   --chatbot-button-bg-color: #0042da;
   --chatbot-button-color: #ffffff;
@@ -163,18 +164,7 @@ textarea {
 .chatbot-container {
   background-image: var(--chatbot-container-bg-image);
   background-color: var(--chatbot-container-bg-color);
-  font-family:
-    'Open Sans',
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    Roboto,
-    Helvetica,
-    Arial,
-    sans-serif,
-    'Apple Color Emoji',
-    'Segoe UI Emoji',
-    'Segoe UI Symbol';
+  font-family: var(--chatbot-container-font-family);
 }
 
 .file-annotation-button {
@@ -446,7 +436,7 @@ textarea {
   background-color: transparent;
   border: none;
   padding: 10px 10px;
-  font-family: 'Poppins', sans-serif;
+  font-family: var(--chatbot-container-font-family);
 }
 @media (max-width: 640px) {
   div[part='bot'] {

--- a/src/components/Bot.tsx
+++ b/src/components/Bot.tsx
@@ -36,6 +36,7 @@ import { removeLocalStorageChatHistory, getLocalStorageChatflow, setLocalStorage
 import { cloneDeep } from 'lodash';
 import { FollowUpPromptBubble } from '@/components/bubbles/FollowUpPromptBubble';
 import { fetchEventSource, EventStreamContentType } from '@microsoft/fetch-event-source';
+import { DEFAULT_FONT_FAMILY } from '@/constants';
 
 export type FileEvent<T = EventTarget> = {
   target: T;
@@ -161,6 +162,7 @@ export type BotProps = {
   formBackgroundColor?: string;
   formTextColor?: string;
   fontSize?: number;
+  fontFamily?: string;
   isFullPage?: boolean;
   footer?: FooterTheme;
   sourceDocsTitle?: string;
@@ -273,11 +275,19 @@ const FeedbackDialog = (props: {
   onSubmit: () => void;
   feedbackValue: string;
   setFeedbackValue: (value: string) => void;
+  fontFamily?: string;
 }) => {
   return (
     <Show when={props.isOpen}>
       <div class="fixed inset-0 rounded-lg flex items-center justify-center backdrop-blur-sm z-50" style={{ background: 'rgba(0, 0, 0, 0.4)' }}>
-        <div class="p-6 rounded-lg shadow-lg max-w-md w-full text-center mx-4 font-sans" style={{ background: 'white', color: 'black' }}>
+        <div
+          class="p-6 rounded-lg shadow-lg max-w-md w-full text-center mx-4"
+          style={{
+            background: 'white',
+            color: 'black',
+            'font-family': props.fontFamily ?? DEFAULT_FONT_FAMILY,
+          }}
+        >
           <h2 class="text-xl font-semibold mb-4 flex justify-center items-center">Your Feedback</h2>
 
           <textarea
@@ -321,6 +331,7 @@ const FormInputView = (props: {
   textColor?: string;
   sendButtonColor?: string;
   fontSize?: number;
+  fontFamily?: string;
 }) => {
   const [formData, setFormData] = createSignal<Record<string, any>>({});
 
@@ -337,7 +348,7 @@ const FormInputView = (props: {
     <div
       class="w-full h-full flex flex-col items-center justify-center px-4 py-8 rounded-lg"
       style={{
-        'font-family': 'Poppins, sans-serif',
+        'font-family': props.fontFamily ?? DEFAULT_FONT_FAMILY,
         'font-size': props.fontSize ? `${props.fontSize}px` : '16px',
         background: props.parentBackgroundColor || defaultBackgroundColor,
         color: props.textColor || defaultTextColor,
@@ -346,7 +357,7 @@ const FormInputView = (props: {
       <div
         class="w-full max-w-md bg-white shadow-lg rounded-lg overflow-hidden"
         style={{
-          'font-family': 'Poppins, sans-serif',
+          'font-family': props.fontFamily ?? DEFAULT_FONT_FAMILY,
           'font-size': props.fontSize ? `${props.fontSize}px` : '16px',
           background: props.backgroundColor || defaultBackgroundColor,
           color: props.textColor || defaultTextColor,
@@ -458,6 +469,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   let chatContainer: HTMLDivElement | undefined;
   let bottomSpacer: HTMLDivElement | undefined;
   let botContainer: HTMLDivElement | undefined;
+  const getFontFamily = () => props.fontFamily ?? DEFAULT_FONT_FAMILY;
 
   const [userInput, setUserInput] = createSignal('');
   const [loading, setLoading] = createSignal(false);
@@ -1742,11 +1754,16 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
           textColor={props?.formTextColor || props.botMessage?.textColor}
           sendButtonColor={props.textInput?.sendButtonColor}
           fontSize={props.fontSize}
+          fontFamily={getFontFamily()}
         />
       ) : (
         <div
           ref={botContainer}
           class={'relative flex w-full h-full text-base overflow-hidden bg-cover bg-center flex-col items-center chatbot-container ' + props.class}
+          style={{
+            '--chatbot-container-font-family': getFontFamily(),
+            'font-family': getFontFamily(),
+          }}
           onDragEnter={handleDrag}
         >
           {isDragActive() && (
@@ -1805,7 +1822,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
                 class="my-2 ml-2"
                 on:click={clearChat}
               >
-                <span style={{ 'font-family': 'Poppins, sans-serif' }}>Clear</span>
+                <span style={{ 'font-family': getFontFamily() }}>Clear</span>
               </DeleteButton>
             </div>
           ) : null}
@@ -1867,6 +1884,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
                           backgroundColor={props.botMessage?.backgroundColor}
                           textColor={props.botMessage?.textColor}
                           fontSize={props.fontSize}
+                          fontFamily={getFontFamily()}
                           showAvatar={props.botMessage?.showAvatar}
                           avatarSrc={props.botMessage?.avatarSrc}
                           leadsConfig={leadsConfig()}
@@ -1959,7 +1977,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
                       </div>
                       <div class="flex items-center">
                         <CancelButton buttonColor={props.textInput?.sendButtonColor} type="button" class="m-0" on:click={onRecordingCancelled}>
-                          <span style={{ 'font-family': 'Poppins, sans-serif' }}>Send</span>
+                          <span style={{ 'font-family': getFontFamily() }}>Send</span>
                         </CancelButton>
                         <SendButton
                           sendButtonColor={props.textInput?.sendButtonColor}
@@ -1968,7 +1986,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
                           class="m-0"
                           on:click={onRecordingStopped}
                         >
-                          <span style={{ 'font-family': 'Poppins, sans-serif' }}>Send</span>
+                          <span style={{ 'font-family': getFontFamily() }}>Send</span>
                         </SendButton>
                       </div>
                     </div>
@@ -1984,6 +2002,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
                   maxCharsWarningMessage={props.textInput?.maxCharsWarningMessage}
                   autoFocus={props.textInput?.autoFocus}
                   fontSize={props.fontSize}
+                  fontFamily={getFontFamily()}
                   disabled={getInputDisabled()}
                   inputValue={userInput()}
                   onInputChange={(value) => setUserInput(value)}
@@ -2028,6 +2047,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
           denyButtonText={props.disclaimer?.denyButtonText}
           onDeny={props.closeBot}
           isFullPage={props.isFullPage}
+          fontFamily={getFontFamily()}
         />
       )}
 
@@ -2041,6 +2061,7 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
           onSubmit={handleSubmitFeedback}
           feedbackValue={feedback()}
           setFeedbackValue={(value) => setFeedback(value)}
+          fontFamily={getFontFamily()}
         />
       )}
     </>

--- a/src/components/bubbles/LeadCaptureBubble.tsx
+++ b/src/components/bubbles/LeadCaptureBubble.tsx
@@ -5,6 +5,7 @@ import { addLeadQuery, LeadCaptureInput } from '@/queries/sendMessageQuery';
 import { SaveLeadButton } from '@/components/buttons/LeadCaptureButtons';
 import { Avatar } from '@/components/avatars/Avatar';
 import { getLocalStorageChatflow, setLocalStorageChatflow } from '@/utils';
+import { DEFAULT_FONT_FAMILY } from '@/constants';
 
 type Props = {
   message: MessageType;
@@ -18,6 +19,7 @@ type Props = {
   textColor?: string;
   sendButtonColor?: string;
   fontSize?: number;
+  fontFamily?: string;
   isLeadSaved: boolean;
   setIsLeadSaved: (value: boolean) => void;
   setLeadEmail: (value: string) => void;
@@ -94,6 +96,7 @@ export const LeadCaptureBubble = (props: Props) => {
           color: props.textColor ?? defaultTextColor,
           'border-radius': '6px',
           'font-size': props.fontSize ? `${props.fontSize}px` : `${defaultFontSize}px`,
+          'font-family': props.fontFamily ?? DEFAULT_FONT_FAMILY,
         }}
       >
         {props.isLeadSaved || getLocalStorageChatflow(props.chatflowid)?.lead ? (
@@ -154,7 +157,11 @@ export const LeadCaptureBubble = (props: Props) => {
                 </div>
               )}
               <div class="flex items-center justify-end gap-1">
-                <SaveLeadButton buttonColor={props.sendButtonColor} isLoading={isLeadSaving()} />
+                <SaveLeadButton
+                  buttonColor={props.sendButtonColor}
+                  isLoading={isLeadSaving()}
+                  fontFamily={props.fontFamily}
+                />
               </div>
             </div>
           </form>

--- a/src/components/buttons/LeadCaptureButtons.tsx
+++ b/src/components/buttons/LeadCaptureButtons.tsx
@@ -1,12 +1,14 @@
 import { JSX, Show } from 'solid-js';
 import { Spinner } from '@/components';
 import { SendButton } from '@/components/buttons/SendButton';
+import { DEFAULT_FONT_FAMILY } from '@/constants';
 
 type LeadCaptureButtonProps = {
   buttonColor?: string;
   isDisabled?: boolean;
   isLoading?: boolean;
   disableIcon?: boolean;
+  fontFamily?: string;
 } & JSX.ButtonHTMLAttributes<HTMLButtonElement>;
 
 // Not being used for now, keep it for future in case we want to allow users to cancel the form
@@ -19,7 +21,12 @@ export const CancelLeadCaptureButton = (props: LeadCaptureButtonProps) => {
         'h-10 p-2 justify-center font-semibold focus:outline-none flex items-center disabled:opacity-50 disabled:cursor-not-allowed disabled:brightness-100 transition-all filter hover:brightness-90 active:brightness-75 ' +
         props.class
       }
-      style={{ background: 'transparent', border: 'none', color: props.buttonColor }}
+      style={{
+        background: 'transparent',
+        border: 'none',
+        color: props.buttonColor,
+        'font-family': props.fontFamily ?? DEFAULT_FONT_FAMILY,
+      }}
       title="Cancel Lead Capture"
     >
       Cancel
@@ -46,7 +53,7 @@ export const SaveLeadButton = (props: LeadCaptureButtonProps) => {
       {...props}
     >
       <Show when={!props.isLoading} fallback={<SaveLeadFallback />}>
-        <span style={{ 'font-family': 'Poppins, sans-serif' }}>Submit</span>
+        <span style={{ 'font-family': props.fontFamily ?? DEFAULT_FONT_FAMILY }}>Submit</span>
       </Show>
     </SendButton>
   );

--- a/src/components/inputs/textInput/components/TextInput.tsx
+++ b/src/components/inputs/textInput/components/TextInput.tsx
@@ -7,6 +7,7 @@ import { ImageUploadButton } from '@/components/buttons/ImageUploadButton';
 import { RecordAudioButton } from '@/components/buttons/RecordAudioButton';
 import { AttachmentUploadButton } from '@/components/buttons/AttachmentUploadButton';
 import { ChatInputHistory } from '@/utils/chatInputHistory';
+import { DEFAULT_FONT_FAMILY } from '@/constants';
 
 type TextInputProps = {
   placeholder?: string;
@@ -15,6 +16,7 @@ type TextInputProps = {
   sendButtonColor?: string;
   inputValue: string;
   fontSize?: number;
+  fontFamily?: string;
   disabled?: boolean;
   onSubmit: (value: string) => void;
   onInputChange: (value: string) => void;
@@ -46,6 +48,7 @@ export const TextInput = (props: TextInputProps) => {
   let fileUploadRef: HTMLInputElement | HTMLTextAreaElement | undefined;
   let imgUploadRef: HTMLInputElement | HTMLTextAreaElement | undefined;
   let audioRef: HTMLAudioElement | undefined;
+  const fontFamily = props.fontFamily ?? DEFAULT_FONT_FAMILY;
 
   const handleInput = (inputValue: string) => {
     const wordCount = inputValue.length;
@@ -146,6 +149,7 @@ export const TextInput = (props: TextInputProps) => {
         margin: 'auto',
         'background-color': props.backgroundColor ?? defaultBackgroundColor,
         color: props.textColor ?? defaultTextColor,
+        'font-family': fontFamily,
       }}
       onKeyDown={handleKeyDown}
     >
@@ -164,7 +168,7 @@ export const TextInput = (props: TextInputProps) => {
               isDisabled={props.disabled || isSendButtonDisabled()}
               on:click={handleImageUploadClick}
             >
-              <span style={{ 'font-family': 'Poppins, sans-serif' }}>Image Upload</span>
+              <span style={{ 'font-family': fontFamily }}>Image Upload</span>
             </ImageUploadButton>
             <input
               style={{ display: 'none' }}
@@ -189,7 +193,7 @@ export const TextInput = (props: TextInputProps) => {
               isDisabled={props.disabled || isSendButtonDisabled()}
               on:click={handleFileUploadClick}
             >
-              <span style={{ 'font-family': 'Poppins, sans-serif' }}>File Upload</span>
+              <span style={{ 'font-family': fontFamily }}>File Upload</span>
             </AttachmentUploadButton>
             <input
               style={{ display: 'none' }}
@@ -217,7 +221,7 @@ export const TextInput = (props: TextInputProps) => {
             isDisabled={props.disabled || isSendButtonDisabled()}
             on:click={props.onMicrophoneClicked}
           >
-            <span style={{ 'font-family': 'Poppins, sans-serif' }}>Record Audio</span>
+            <span style={{ 'font-family': fontFamily }}>Record Audio</span>
           </RecordAudioButton>
         ) : null}
         <SendButton
@@ -227,7 +231,7 @@ export const TextInput = (props: TextInputProps) => {
           class="m-0 h-14 flex items-center justify-center"
           on:click={submit}
         >
-          <span style={{ 'font-family': 'Poppins, sans-serif' }}>Send</span>
+          <span style={{ 'font-family': fontFamily }}>Send</span>
         </SendButton>
       </div>
     </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
 import type { BubbleProps } from './features/bubble';
 
+export const DEFAULT_FONT_FAMILY = 'Poppins, sans-serif';
+
 export const defaultBotProps: BubbleProps = {
   chatflowid: '',
   apiHost: undefined,

--- a/src/features/bubble/components/Bubble.tsx
+++ b/src/features/bubble/components/Bubble.tsx
@@ -16,6 +16,7 @@ export const Bubble = (props: BubbleProps) => {
 
   const [isBotOpened, setIsBotOpened] = createSignal(false);
   const [isBotStarted, setIsBotStarted] = createSignal(false);
+  const [isWidgetVisible, setIsWidgetVisible] = createSignal(true);
   const [buttonPosition, setButtonPosition] = createSignal({
     bottom: bubbleProps.theme?.button?.bottom ?? 20,
     right: bubbleProps.theme?.button?.right ?? 20,
@@ -30,6 +31,12 @@ export const Bubble = (props: BubbleProps) => {
     setIsBotOpened(false);
   };
 
+  const hideWidget = () => {
+    setIsBotOpened(false);
+    setIsBotStarted(false);
+    setIsWidgetVisible(false);
+  };
+
   const toggleBot = () => {
     isBotOpened() ? closeBot() : openBot();
   };
@@ -41,6 +48,17 @@ export const Bubble = (props: BubbleProps) => {
   const buttonSize = getBubbleButtonSize(props.theme?.button?.size); // Default to 48px if size is not provided
   const buttonBottom = props.theme?.button?.bottom ?? 20;
   const chatWindowBottom = buttonBottom + buttonSize + 10; // Adjust the offset here for slight shift
+  const showCloseButton = bubbleProps.theme?.button?.showCloseButton ?? true;
+  const closeButtonBackgroundColor = bubbleProps.theme?.button?.closeButtonBackgroundColor ?? 'rgba(17, 24, 39, 0.8)';
+  const closeButtonIconColor = bubbleProps.theme?.button?.closeButtonIconColor ?? defaultIconColor;
+  const closeButtonSize = 24;
+  const closeButtonGap = 8;
+
+  const getCloseButtonBottom = () =>
+    Math.max(0, Math.min(buttonPosition().bottom + buttonSize + closeButtonGap, window.innerHeight - closeButtonSize));
+
+  const getCloseButtonRight = () =>
+    Math.max(0, Math.min(buttonPosition().right, window.innerWidth - closeButtonSize));
 
   // Add viewport meta tag dynamically
   createEffect(() => {
@@ -62,25 +80,55 @@ export const Bubble = (props: BubbleProps) => {
         <style>{props.theme?.customCSS}</style>
       </Show>
       <style>{styles}</style>
-      <Tooltip
-        showTooltip={showTooltip && !isBotOpened()}
-        position={buttonPosition()}
-        buttonSize={buttonSize}
-        tooltipMessage={bubbleProps.theme?.tooltip?.tooltipMessage}
-        tooltipBackgroundColor={bubbleProps.theme?.tooltip?.tooltipBackgroundColor}
-        tooltipTextColor={bubbleProps.theme?.tooltip?.tooltipTextColor}
-        tooltipFontSize={bubbleProps.theme?.tooltip?.tooltipFontSize} // Set the tooltip font size
-      />
-      <BubbleButton
-        {...bubbleProps.theme?.button}
-        toggleBot={toggleBot}
-        isBotOpened={isBotOpened()}
-        setButtonPosition={setButtonPosition}
-        dragAndDrop={bubbleProps.theme?.button?.dragAndDrop ?? false}
-        autoOpen={bubbleProps.theme?.button?.autoWindowOpen?.autoOpen ?? false}
-        openDelay={bubbleProps.theme?.button?.autoWindowOpen?.openDelay}
-        autoOpenOnMobile={bubbleProps.theme?.button?.autoWindowOpen?.autoOpenOnMobile ?? false}
-      />
+      <Show when={isWidgetVisible()}>
+        <Tooltip
+          showTooltip={showTooltip && !isBotOpened()}
+          position={buttonPosition()}
+          buttonSize={buttonSize}
+          tooltipMessage={bubbleProps.theme?.tooltip?.tooltipMessage}
+          tooltipBackgroundColor={bubbleProps.theme?.tooltip?.tooltipBackgroundColor}
+          tooltipTextColor={bubbleProps.theme?.tooltip?.tooltipTextColor}
+          tooltipFontSize={bubbleProps.theme?.tooltip?.tooltipFontSize} // Set the tooltip font size
+          fontFamily={bubbleProps.theme?.chatWindow?.fontFamily}
+        />
+      </Show>
+      <Show when={isWidgetVisible()}>
+        <BubbleButton
+          {...bubbleProps.theme?.button}
+          toggleBot={toggleBot}
+          isBotOpened={isBotOpened()}
+          setButtonPosition={setButtonPosition}
+          dragAndDrop={bubbleProps.theme?.button?.dragAndDrop ?? false}
+          autoOpen={bubbleProps.theme?.button?.autoWindowOpen?.autoOpen ?? false}
+          openDelay={bubbleProps.theme?.button?.autoWindowOpen?.openDelay}
+          autoOpenOnMobile={bubbleProps.theme?.button?.autoWindowOpen?.autoOpenOnMobile ?? false}
+        />
+      </Show>
+      <Show when={isWidgetVisible() && !isBotOpened() && showCloseButton}>
+        <button
+          type="button"
+          class="fixed flex items-center justify-center rounded-full shadow-md transition-transform duration-200 hover:scale-110 active:scale-95"
+          style={{
+            right: `${getCloseButtonRight()}px`,
+            bottom: `${getCloseButtonBottom()}px`,
+            width: `${closeButtonSize}px`,
+            height: `${closeButtonSize}px`,
+            'background-color': closeButtonBackgroundColor,
+            color: closeButtonIconColor,
+            'z-index': 42424242,
+          }}
+          onClick={hideWidget}
+          aria-label="Hide chat"
+          title="Hide Chat"
+        >
+          <svg viewBox="0 0 24 24" width="16" height="16">
+            <path
+              fill={closeButtonIconColor}
+              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
+            />
+          </svg>
+        </button>
+      </Show>
       <div
         part="bot"
         style={{
@@ -98,6 +146,7 @@ export const Bubble = (props: BubbleProps) => {
           'z-index': 42424242,
           bottom: `${Math.min(buttonPosition().bottom + buttonSize + 10, window.innerHeight - chatWindowBottom)}px`,
           right: `${Math.max(0, Math.min(buttonPosition().right, window.innerWidth - (bubbleProps.theme?.chatWindow?.width ?? 410) - 10))}px`,
+          display: isWidgetVisible() ? 'block' : 'none',
         }}
         class={
           `fixed sm:right-5 rounded-lg w-full sm:w-[400px] max-h-[704px]` +
@@ -143,6 +192,7 @@ export const Bubble = (props: BubbleProps) => {
               userMessage={bubbleProps.theme?.chatWindow?.userMessage}
               feedback={bubbleProps.theme?.chatWindow?.feedback}
               fontSize={bubbleProps.theme?.chatWindow?.fontSize}
+              fontFamily={bubbleProps.theme?.chatWindow?.fontFamily}
               footer={bubbleProps.theme?.chatWindow?.footer}
               sourceDocsTitle={bubbleProps.theme?.chatWindow?.sourceDocsTitle}
               starterPrompts={bubbleProps.theme?.chatWindow?.starterPrompts}

--- a/src/features/bubble/components/Tooltip.tsx
+++ b/src/features/bubble/components/Tooltip.tsx
@@ -13,6 +13,7 @@ type TooltipProps = {
   tooltipBackgroundColor?: string;
   tooltipTextColor?: string;
   tooltipFontSize?: number; // Add tooltipFontSize to props
+  fontFamily?: string;
 };
 
 const Tooltip = (props: TooltipProps) => {
@@ -52,6 +53,7 @@ const Tooltip = (props: TooltipProps) => {
           '--tooltip-background-color': backgroundColor,
           '--tooltip-text-color': textColor,
           '--tooltip-font-size': fontSize,
+          'font-family': props.fontFamily,
         }}
       >
         {formattedTooltipMessage}

--- a/src/features/bubble/types.ts
+++ b/src/features/bubble/types.ts
@@ -70,6 +70,7 @@ export type ChatWindowTheme = {
   height?: number;
   width?: number;
   fontSize?: number;
+  fontFamily?: string;
   userMessage?: UserMessageTheme;
   botMessage?: BotMessageTheme;
   textInput?: TextInputTheme;
@@ -93,6 +94,9 @@ export type ButtonTheme = {
   right?: number;
   dragAndDrop?: boolean; // parameter to enable drag and drop(true or false)
   autoWindowOpen?: autoWindowOpenTheme;
+  showCloseButton?: boolean;
+  closeButtonBackgroundColor?: string;
+  closeButtonIconColor?: string;
 };
 
 export type ToolTipTheme = {

--- a/src/features/full/components/Full.tsx
+++ b/src/features/full/components/Full.tsx
@@ -80,6 +80,7 @@ export const Full = (props: FullProps, { element }: { element: HTMLElement }) =>
             userMessage={props.theme?.chatWindow?.userMessage}
             feedback={props.theme?.chatWindow?.feedback}
             fontSize={props.theme?.chatWindow?.fontSize}
+            fontFamily={props.theme?.chatWindow?.fontFamily}
             footer={props.theme?.chatWindow?.footer}
             starterPrompts={props.theme?.chatWindow?.starterPrompts}
             chatflowid={props.chatflowid}

--- a/src/features/popup/components/DisclaimerPopup.tsx
+++ b/src/features/popup/components/DisclaimerPopup.tsx
@@ -1,4 +1,5 @@
 import { Show, splitProps } from 'solid-js';
+import { DEFAULT_FONT_FAMILY } from '@/constants';
 
 export type DisclaimerPopupProps = {
   isOpen?: boolean;
@@ -15,6 +16,7 @@ export type DisclaimerPopupProps = {
   textColor?: string;
   buttonTextColor?: string;
   denyButtonBgColor?: string;
+  fontFamily?: string;
 };
 
 export const DisclaimerPopup = (props: DisclaimerPopupProps) => {
@@ -33,6 +35,7 @@ export const DisclaimerPopup = (props: DisclaimerPopupProps) => {
     'denyButtonBgColor',
     'blurredBackgroundColor',
     'backgroundColor',
+    'fontFamily',
   ]);
 
   const handleAccept = () => {
@@ -50,8 +53,12 @@ export const DisclaimerPopup = (props: DisclaimerPopupProps) => {
         style={{ background: popupProps.blurredBackgroundColor || 'rgba(0, 0, 0, 0.4)' }}
       >
         <div
-          class="p-10 rounded-lg shadow-lg max-w-md w-full text-center mx-4 font-sans"
-          style={{ background: popupProps.backgroundColor || 'white', color: popupProps.textColor || 'black' }}
+          class="p-10 rounded-lg shadow-lg max-w-md w-full text-center mx-4"
+          style={{
+            background: popupProps.backgroundColor || 'white',
+            color: popupProps.textColor || 'black',
+            'font-family': popupProps.fontFamily ?? DEFAULT_FONT_FAMILY,
+          }}
         >
           <h2 class="text-2xl font-semibold mb-4 flex justify-center items-center">{popupProps.title ?? 'Disclaimer'}</h2>
 


### PR DESCRIPTION
## Summary
- add an optional close control to hide the floating bubble until the next reload
- propagate font family configuration through the chat widget and supporting popups
- expose new theme fields for close button styling and rely on CSS variables/defaults for font inheritance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cd4366617c8331850ff8e6176c9625